### PR TITLE
Hacktoberfest - Rename jenkinsci/jnlp-slave -> jenkins/inbound-agent

### DIFF
--- a/src/main/resources/com/elasticbox/jenkins/k8s/plugin/clouds/PodSlaveConfig/default-jenkins-slave-pod.yaml
+++ b/src/main/resources/com/elasticbox/jenkins/k8s/plugin/clouds/PodSlaveConfig/default-jenkins-slave-pod.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
     containers:
       - name: "jenkins-slave"
-        image: "jenkinsci/jnlp-slave"
+        image: "jenkins/inbound-agent"
         env:
           - name: "JENKINS_URL"
             value: "${JENKINS_URL}"

--- a/src/main/resources/com/elasticbox/jenkins/k8s/plugin/clouds/PodSlaveConfig/help-podYaml.html
+++ b/src/main/resources/com/elasticbox/jenkins/k8s/plugin/clouds/PodSlaveConfig/help-podYaml.html
@@ -11,7 +11,7 @@ metadata:
 spec:
   containers:
     - name: "jenkins-slave"
-      image: "jenkinsci/jnlp-slave"
+      image: "jenkins/inbound-agent"
   env:
     - name: "JENKINS_URL"
       value: "${JENKINS_URL}"


### PR DESCRIPTION
As mentioned in https://www.jenkins.io/blog/2020/05/06/docker-agent-image-renaming/ and https://issues.jenkins-ci.org/browse/JENKINS-42846